### PR TITLE
fix: specify Vite framework in vercel.json to resolve react-scripts build error

### DIFF
--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,0 +1,6 @@
+{
+  "framework": "vite",
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
+  "installCommand": "npm install"
+}


### PR DESCRIPTION
This PR updates frontend/vercel.json to specify the framework as Vite, fixing the build error on Vercel caused by it trying to use react-scripts.